### PR TITLE
fix: Map offscreen scan data to sitemapAnalysis format for results page

### DIFF
--- a/globalCherckerWebSiteCQ/service_worker.js
+++ b/globalCherckerWebSiteCQ/service_worker.js
@@ -2374,9 +2374,19 @@ async function handleStartOffscreenBatchAnalysis(request, sendResponse) {
       throw new Error('URLs or sitemap URL required');
     }
 
-    // Sauvegarder les résultats
+    // Mapper les résultats pour compatibilité avec results.js
+    // OffscreenBatchAnalyzer retourne { success: [...], errors: [...], stats: {...} }
+    // results.js attend { results: [...], errors: [...], stats: {...} }
+    const mappedResults = {
+      results: results.success,  // Mapper success → results
+      errors: results.errors,
+      stats: results.stats
+    };
+
+    // Sauvegarder les résultats dans les deux formats
     await chrome.storage.local.set({
-      offscreenBatchResults: results,
+      sitemapAnalysis: mappedResults,        // Format attendu par results.js
+      offscreenBatchResults: results,        // Format natif pour référence
       offscreenBatchTimestamp: Date.now()
     });
 


### PR DESCRIPTION
Le scan multipage offscreen était disponible dans le service worker mais ne s'affichait pas sur la page de résultats à cause d'une discordance entre les clés de stockage utilisées.

Problème:
- OffscreenBatchAnalyzer stockait dans 'offscreenBatchResults'
- results.js recherchait dans 'sitemapAnalysis'

Solution:
- Mapper results.success → results pour compatibilité
- Stocker dans 'sitemapAnalysis' (format attendu par results.js)
- Conserver 'offscreenBatchResults' pour référence native

Fixes: #86 (related to offscreen scan data delivery)